### PR TITLE
Fixed index out of bounds error in /test/jdk/build/AbsPathsInImage.java, now consistent with jdk17 test

### DIFF
--- a/test/jdk/build/AbsPathsInImage.java
+++ b/test/jdk/build/AbsPathsInImage.java
@@ -208,7 +208,7 @@ public class AbsPathsInImage {
             for (byte[] searchPattern : searchPatterns) {
                 boolean found = true;
                 for (int j = 0; j < searchPattern.length; j++) {
-                    if ((i + j > data.length || data[i + j] != searchPattern[j])) {
+                    if ((i + j >= data.length || data[i + j] != searchPattern[j])) {
                         found = false;
                         break;
                     }


### PR DESCRIPTION
Here is the line in jdk17 where this fix was applied, this PR just propagates the fix to jdk11 as well
https://github.com/adoptium/jdk17u/blob/ca0f148681114b64ba0b40ea77b89a5e9bc68657/test/jdk/build/AbsPathsInImage.java#L215